### PR TITLE
Cancel_flow_run

### DIFF
--- a/proxy/service.py
+++ b/proxy/service.py
@@ -1,4 +1,5 @@
 """interface with prefect's python client api"""
+import asyncio
 import os
 from time import sleep
 import requests
@@ -1007,14 +1008,14 @@ def set_deployment_schedule(deployment_id: str, status: str) -> None:
 
     return None
 
-def cancel_flow_run(flow_run_id: str) -> dict:
+async def cancel_flow_run(flow_run_id: str) -> dict:
     """"Cancel a flow run"""
     if not isinstance(flow_run_id, str):
         raise TypeError("flow_run_id must be a string")
     try:
-        with get_client() as client:
+        async with get_client() as client:
             # set the state of the provided flow-run to cancelled
-            client.set_flow_run_state(flow_run_id=flow_run_id, state=Cancelled())
+            await client.set_flow_run_state(flow_run_id=flow_run_id, state=Cancelled())
     except Exception as err:
         logger.exception(err)
         raise PrefectException("failed to cancel flow-run") from err

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1496,20 +1496,20 @@ def test_set_deployment_schedule_result():
         assert result is None
 
 
-def test_cancel_flow_runs_type_error():
+async def test_cancel_flow_runs_type_error():
     with pytest.raises(TypeError):
-        cancel_flow_run(123)
+        await cancel_flow_run(123)
 
-def test_cancel_flow_run_failure():
-    with patch("proxy.service.cancel_flow_run") as mock_cancel:
+async def test_cancel_flow_run_failure():
+    with patch("proxy.service.get_client") as mock_cancel:
         mock_cancel.side_effect = Exception("exception")
         with pytest.raises(PrefectException) as excinfo:
-            cancel_flow_run("flow_run_id")
+            await cancel_flow_run("flow_run_id")
             assert str(excinfo.value) == "failed to cancel flow-run"
 
 
-def test_cancel_flow_run_success():
-    with patch("proxy.service.cancel_flow_run"):
+async def test_cancel_flow_run_success():
+    with patch("proxy.service.get_client"):
         flow_run_id = "valid_flow_run_id"
-        result  = cancel_flow_run(flow_run_id)
+        result  = await cancel_flow_run(flow_run_id)
         assert result is None

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -56,6 +56,7 @@ from proxy.service import (
     CronSchedule,
     post_deployment_flow_run,
     create_secret_block,
+    cancel_flow_run,
 )
 
 
@@ -1492,4 +1493,23 @@ def test_set_deployment_schedule_result():
     with patch("proxy.service.prefect_post"):
         deployment_id = "deployment_id"
         result = set_deployment_schedule(deployment_id, "active")
+        assert result is None
+
+
+def test_cancel_flow_runs_type_error():
+    with pytest.raises(TypeError):
+        cancel_flow_run(123)
+
+def test_cancel_flow_run_failure():
+    with patch("proxy.service.cancel_flow_run") as mock_cancel:
+        mock_cancel.side_effect = Exception("exception")
+        with pytest.raises(PrefectException) as excinfo:
+            cancel_flow_run("flow_run_id")
+            assert str(excinfo.value) == "failed to cancel flow-run"
+
+
+def test_cancel_flow_run_success():
+    with patch("proxy.service.cancel_flow_run"):
+        flow_run_id = "valid_flow_run_id"
+        result  = cancel_flow_run(flow_run_id)
         assert result is None


### PR DESCRIPTION
## Description
This PR closes #104 . A new function has been added which accepts the `flow_run_id` as a parameter and cancels it.

## Implementation Details
1. Inside `proxy/service.py`, a new function `cancel_flow_run` has been added which takes `flow_run_id` as a parameter and change it's state to `Cancelled`.
2. Inside `tests/test_service.py`:
     - function `test_cancel_flow_run_type_error` has been added to check for any `flow_run_id` type error.
     - function `test_cancel_flow_run_failure` had been added to handle any case of failure.
     - function `test_cancel_flow_run_success` checks for successful execution of the function.

## Tasks Completed
- [x] #104 
- [x]  A function in `proxy/service.py `called `cancel_flow_run(flow_run_id: str)`
- [x] 3 functions in `tests/test_service.py` which tests this new function

