### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ Since Prefect exposes an async Python interface and Django does not play well wi
 
 These endpoints will be called only from the Django server or from testing scripts. More project documentation can be found in [the wiki](https://github.com/DalgoT4D/prefect-proxy/wiki)
 
-
 ## Installation instructions
 
-Install the Python dependencies
+Clone the [Prefect Proxy](https://github.com/DalgoT4D/prefect-proxy) repository
 
-    pip install -r requirements.txt
+In the cloned repository, run the following commands:
+
+- `pyenv local 3.10`
+
+- `pyenv exec python -m venv venv`
+
+- `source venv/bin/activate`
+
+- `pip install --upgrade pip`
+
+- `pip install -r requirements.txt`
+
+- create `.env` from `.env.template`
+- set the value for the `LOGDIR` in the `.env` file with the name of the directory to hold the logs. The directory will be automatically created on running the prefect proxy
 
 ## Run instructions
 


### PR DESCRIPTION
## Fix: Setup Instruction Issues
### Issue
Some installation steps on the ReadMe were missing. This made it unclear and the setup threw an error if the user does not set the `LOGDIR` value in the `.env` file

### Changes
 Updated the README to include the following:
- A step to create the virtual environment - the assumption here is prefect-proxy should run in its own venv
- A step to create the `.env` file from the `env.template` file
- A step to update the value for the `LOGDIR` in the `.env` file