### PR TITLE
DDP 98 - Add workflow to push docker image to dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,5 +46,5 @@ jobs:
           tags: |
             tech4dev/prefect-proxy:${{ env.RELEASE_NUMBER }}
             tech4dev/prefect-proxy:latest
-          cache-from: type=registry,ref=jeph45/prefect-proxy:latest
+          cache-from: type=registry,ref=tech4dev/prefect-proxy:latest
           cache-to: type=inline

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+# This workflow builds and pushes a new docker image
+# to dockerhub whenever a new release is published
+
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to docker registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_PASSWORD}}
+
+      - name: Build and push docker image to registry
+        uses: docker/build-push-action@v5
+        with:
+          context: Docker/
+          push: true
+          tags: tech4dev/prefect-proxy:{{ github.event.release.tag_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Build and push docker image to registry
         uses: docker/build-push-action@v5
         with:
-          context: Docker/
+          context: .
+          file: ./Docker/Dockerfile
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_VERSION=${{ env.RELEASE_NUMBER }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Set release number
         run: echo "RELEASE_NUMBER=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to docker registry
         uses: docker/login-action@v3
         with:
@@ -32,6 +38,7 @@ jobs:
         with:
           context: .
           file: ./Docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_VERSION=${{ env.RELEASE_NUMBER }}"
@@ -39,3 +46,5 @@ jobs:
           tags: |
             tech4dev/prefect-proxy:${{ env.RELEASE_NUMBER }}
             tech4dev/prefect-proxy:latest
+          cache-from: type=registry,ref=jeph45/prefect-proxy:latest
+          cache-to: type=inline

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
     types: [published]
 
 jobs:
-  push_to_registry:
+  push_image_to_registry:
     name: Push Docker image to docker hub
     runs-on: ubuntu-latest
     steps:
@@ -26,4 +26,4 @@ jobs:
         with:
           context: Docker/
           push: true
-          tags: tech4dev/prefect-proxy:{{ github.event.release.tag_name }}
+          tags: tech4dev/prefect-proxy: ${{ github.event.release.tag_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,4 +26,6 @@ jobs:
         with:
           context: Docker/
           push: true
-          tags: tech4dev/prefect-proxy: ${{ github.event.release.tag_name }}
+          tags: |
+            tech4dev/prefect-proxy:${{ github.event.release.tag_name }}
+            tech4dev/prefect-proxy:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set build date
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+
+      - name: Set release number
+        run: echo "RELEASE_NUMBER=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
       - name: Login to docker registry
         uses: docker/login-action@v3
         with:
@@ -25,7 +31,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: Docker/
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_VERSION=${{ env.RELEASE_NUMBER }}"
           push: true
           tags: |
-            tech4dev/prefect-proxy:${{ github.event.release.tag_name }}
+            tech4dev/prefect-proxy:${{ env.RELEASE_NUMBER }}
             tech4dev/prefect-proxy:latest


### PR DESCRIPTION
# Add workflow to push docker image to dockerhub

- This PR adds a Github action workflow(`docker.yml`) to push the prefect proxy image to the [tech4dev](https://hub.docker.com/u/tech4dev) dockerhub registry whenever a new release is published
- The image is tagged with the release version number