### PR TITLE
Cancel queued manual job

### DIFF
--- a/proxy/main.py
+++ b/proxy/main.py
@@ -42,7 +42,7 @@ from proxy.service import (
     patch_dbt_cloud_creds_block,
     get_dbt_cloud_creds_block,
     update_airbyte_server_block,
-    set_cancel_queued_flow_run
+    set_cancel_queued_flow_run,
 )
 from proxy.schemas import (
     AirbyteServerCreate,
@@ -64,7 +64,7 @@ from proxy.schemas import (
     DbtCliProfileBlockUpdate,
     RunAirbyteResetConnection,
     ScheduleFlowRunRequest,
-    CancelQueuedManualJob
+    CancelQueuedManualJob,
 )
 from proxy.flows import run_airbyte_connection_flow
 
@@ -877,10 +877,10 @@ async def get_dbt_cloud_creds(request: Request, block_name: str):
 
 
 @app.post("/proxy/flow_runs/{flow_run_id}/set_state")
-def cancel_queued_flow_run(request:Request, flow_run_id: str, payload: CancelQueuedManualJob):
+def cancel_queued_flow_run(request: Request, flow_run_id: str, payload: CancelQueuedManualJob):
     """Cancel a queued manual sync"""
     try:
-        set_cancel_queued_flow_run(flow_run_id , payload)
+        set_cancel_queued_flow_run(flow_run_id, payload)
     except Exception as error:
         logger.exception(error)
         raise HTTPException(

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -42,6 +42,7 @@ from proxy.service import (
     patch_dbt_cloud_creds_block,
     get_dbt_cloud_creds_block,
     update_airbyte_server_block,
+    cancel_queued_manual_job
 )
 from proxy.schemas import (
     AirbyteServerCreate,
@@ -63,6 +64,7 @@ from proxy.schemas import (
     DbtCliProfileBlockUpdate,
     RunAirbyteResetConnection,
     ScheduleFlowRunRequest,
+    CancelQueuedManualJob
 )
 from proxy.flows import run_airbyte_connection_flow
 
@@ -872,3 +874,17 @@ async def get_dbt_cloud_creds(request: Request, block_name: str):
             status_code=400, detail="failed to fetch dbt cloud creds block"
         ) from error
     return data
+
+
+@app.post("/proxy/flow_runs/{flow_run_id}/set_state")
+def cancel_queued_manual_job(request: Request, flow_run_id: str, payload: CancelQueuedManualJob):
+    """Cancel a queued manual sync"""
+    try:
+        cancel_queued_manual_job(flow_run_id=flow_run_id , payload = payload)
+    except Exception as error:
+        logger.exception(error)
+        raise HTTPException(
+            status_code=400, detail="failed to cancel the queued manual job"
+        ) from error
+
+    return {"success": 1}

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -42,7 +42,7 @@ from proxy.service import (
     patch_dbt_cloud_creds_block,
     get_dbt_cloud_creds_block,
     update_airbyte_server_block,
-    cancel_queued_manual_job
+    set_cancel_queued_flow_run
 )
 from proxy.schemas import (
     AirbyteServerCreate,
@@ -877,10 +877,10 @@ async def get_dbt_cloud_creds(request: Request, block_name: str):
 
 
 @app.post("/proxy/flow_runs/{flow_run_id}/set_state")
-def cancel_queued_manual_job(request: Request, flow_run_id: str, payload: CancelQueuedManualJob):
+def cancel_queued_flow_run(request:Request, flow_run_id: str, payload: CancelQueuedManualJob):
     """Cancel a queued manual sync"""
     try:
-        cancel_queued_manual_job(flow_run_id=flow_run_id , payload = payload)
+        set_cancel_queued_flow_run(flow_run_id , payload)
     except Exception as error:
         logger.exception(error)
         raise HTTPException(

--- a/proxy/schemas.py
+++ b/proxy/schemas.py
@@ -290,14 +290,15 @@ class DbtCloudCredsBlockPatch(BaseModel):
     api_key: str = None
 
 
-
 class CancelQueuedManualJob(BaseModel):
     """Payload to cancel a manually queued job"""
+
     class State(BaseModel):
         name: str
-        type: Literal["CANCELLING"]  
+        type: Literal["CANCELLING"]
 
     state: State
-    force: bool 
+    force: bool
+
     class Config:
-        from_attributes = True  
+        from_attributes = True

--- a/proxy/schemas.py
+++ b/proxy/schemas.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 from pydantic import BaseModel, Extra
 from datetime import datetime
+from typing import Literal
 
 
 class AirbyteServerCreate(BaseModel):
@@ -287,3 +288,16 @@ class DbtCloudCredsBlockPatch(BaseModel):
     block_name: str
     account_id: int = None
     api_key: str = None
+
+
+
+class CancelQueuedManualJob(BaseModel):
+    """Payload to cancel a manually queued job"""
+    class State(BaseModel):
+        name: str
+        type: Literal["CANCELLING"]  
+
+    state: State
+    force: bool 
+    class Config:
+        from_attributes = True  

--- a/proxy/schemas.py
+++ b/proxy/schemas.py
@@ -298,7 +298,7 @@ class CancelQueuedManualJob(BaseModel):
         type: Literal["CANCELLING"]
 
     state: State
-    force: bool
+    force: str
 
     class Config:
         from_attributes = True

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -1201,18 +1201,19 @@ async def get_dbt_cloud_creds_block(block_name: str) -> dict:
             status_code=404,
             detail=f"No dbt cloud credentials block found named {block_name}",
         )
+        
 
-def cancel_queued_manual_job(flow_run_id: str, payload:CancelQueuedManualJob ):
+def set_cancel_queued_flow_run(flow_run_id: str, payload:CancelQueuedManualJob ):
     if not isinstance(flow_run_id, str):
         raise TypeError("flow_run_id must be a string")
     try:
-        res = prefect_get(f"/api/flow_run_states/{flow_run_id}")
-        if res.type != "PENDING":
+        flow_run = prefect_get(f"flow_runs/{flow_run_id}")
+        if flow_run.get("state_type") != "PENDING" and flow_run.get("state_type") != "SCHEDULED":
             raise ValueError("Unable to cancel a non-queued job.") 
 
         prefect_post(
             f"flow_runs/{flow_run_id}/set_state",
-            payload=payload
+            payload=payload.dict()
         )
     except Exception as err:
         logger.exception(err)

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -1203,14 +1203,16 @@ async def get_dbt_cloud_creds_block(block_name: str) -> dict:
         )
         
 
-def set_cancel_queued_flow_run(flow_run_id: str, payload:CancelQueuedManualJob ):
+def set_cancel_queued_flow_run(flow_run_id: str, payload: CancelQueuedManualJob):
     if not isinstance(flow_run_id, str):
         raise TypeError("flow_run_id must be a string")
-    try:
-        flow_run = prefect_get(f"flow_runs/{flow_run_id}")
-        if flow_run.get("state_type") != "PENDING" and flow_run.get("state_type") != "SCHEDULED":
-            raise ValueError("Unable to cancel a non-queued job.") 
+    
+    flow_run = prefect_get(f"flow_runs/{flow_run_id}")
+    
+    if flow_run.get("state_type") not in ["PENDING", "SCHEDULED"]:
+        raise ValueError("Unable to cancel a non-queued job.")
 
+    try:
         prefect_post(
             f"flow_runs/{flow_run_id}/set_state",
             payload=payload.dict()
@@ -1218,4 +1220,3 @@ def set_cancel_queued_flow_run(flow_run_id: str, payload:CancelQueuedManualJob )
     except Exception as err:
         logger.exception(err)
         raise PrefectException("failed to cancel queued job") from err
-    return None

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -41,7 +41,7 @@ from proxy.schemas import (
     DbtCliProfileBlockUpdate,
     DeploymentUpdate2,
     DbtCloudCredsBlockPatch,
-    CancelQueuedManualJob
+    CancelQueuedManualJob,
 )
 
 
@@ -1201,22 +1201,19 @@ async def get_dbt_cloud_creds_block(block_name: str) -> dict:
             status_code=404,
             detail=f"No dbt cloud credentials block found named {block_name}",
         )
-        
+
 
 def set_cancel_queued_flow_run(flow_run_id: str, payload: CancelQueuedManualJob):
     if not isinstance(flow_run_id, str):
         raise TypeError("flow_run_id must be a string")
-    
+
     flow_run = prefect_get(f"flow_runs/{flow_run_id}")
-    
+
     if flow_run.get("state_type") not in ["PENDING", "SCHEDULED"]:
         raise ValueError("Unable to cancel a non-queued job.")
 
     try:
-        prefect_post(
-            f"flow_runs/{flow_run_id}/set_state",
-            payload=payload.dict()
-        )
+        prefect_post(f"flow_runs/{flow_run_id}/set_state", payload=payload.dict())
     except Exception as err:
         logger.exception(err)
         raise PrefectException("failed to cancel queued job") from err

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -59,7 +59,7 @@ from proxy.service import (
     get_flow_run_logs_v2,
     retry_flow_run,
     get_long_running_flow_runs,
-    set_cancel_queued_flow_run
+    set_cancel_queued_flow_run,
 )
 
 
@@ -1564,15 +1564,15 @@ def test_get_long_running_flow_runs():
     mock_prefect_post.assert_called_once_with("flow_runs/filter", request_parameters)
 
 
-
-
 class PayloadModel(BaseModel):
     state: dict
     force: str
 
+
 @pytest.fixture
 def mock_payload():
     return PayloadModel(state={"name": "Cancelling", "type": "CANCELLING"}, force="TRUE")
+
 
 @patch("proxy.service.prefect_get")
 @patch("proxy.service.prefect_post")
@@ -1583,8 +1583,7 @@ def test_cancel_flow_run_pending(mock_prefect_post, mock_prefect_get, mock_paylo
     set_cancel_queued_flow_run("valid_flow_run_id", mock_payload)
 
     mock_prefect_post.assert_called_once_with(
-        "flow_runs/valid_flow_run_id/set_state",
-        payload=mock_payload
+        "flow_runs/valid_flow_run_id/set_state", payload=mock_payload
     )
 
 
@@ -1597,8 +1596,7 @@ def test_cancel_flow_run_scheduled(mock_prefect_post, mock_prefect_get, mock_pay
     set_cancel_queued_flow_run("valid_flow_run_id", mock_payload)
 
     mock_prefect_post.assert_called_once_with(
-        "flow_runs/valid_flow_run_id/set_state",
-        payload=mock_payload
+        "flow_runs/valid_flow_run_id/set_state", payload=mock_payload
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint that allows users to cancel queued manual sync jobs for specific flow runs.
  - The cancellation functionality includes a structured payload for improved request handling.

- **Bug Fixes**
  - Enhanced error handling to prevent cancellation attempts on flow runs that are not in a cancellable state.

- **Tests**
  - Added new tests to validate the cancellation functionality for flow runs in various states, ensuring robust coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->