### PR TITLE
increase the default time out for schema refresh flows

### DIFF
--- a/proxy/prefect_flows.py
+++ b/proxy/prefect_flows.py
@@ -172,7 +172,7 @@ def run_refresh_schema_flow(payload: dict, catalog_diff: dict):
         connection_block = AirbyteConnection(
             airbyte_server=serverblock,
             connection_id=payload["connection_id"],
-            timeout=payload["timeout"] or 15,
+            timeout=payload["timeout"] or 100,
         )
         update_connection_schema(connection_block, catalog_diff=catalog_diff)
         return True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Extended the default connection waiting period (from 15 to 100 seconds) to enhance operation stability and reduce premature timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->