### PR TITLE
deployment create bug , validation error

### DIFF
--- a/proxy/service.py
+++ b/proxy/service.py
@@ -647,10 +647,12 @@ def post_deployment_v1(payload: DeploymentCreate2) -> dict:
             tags=[payload.org_slug],
             parameters=payload.deployment_params,
             schedules=(
-                [{"schedule": CronSchedule(cron=payload.cron), "active": True}]
+                [{"schedule": CronSchedule(cron=payload.cron).model_dump(), "active": True}]
                 if payload.cron
                 else []
             ),
+            build=False,
+            push=False,
         )
 
     except Exception as error:


### PR DESCRIPTION
Without the change it throws this validation error

```
4|prefect-proxy  | pydantic_core._pydantic_core.ValidationError: 4 validation errors for RunnerDeployment
4|prefect-proxy  | schedule.function-after[validate_timezone(), IntervalSchedule]
4|prefect-proxy  |   Input should be a valid dictionary or instance of IntervalSchedule [type=model_type, input_value=CronSchedule(cron='0 1 * ...ezone=None, day_or=True), input_type=CronSchedule]
4|prefect-proxy  |     For further information visit https://errors.pydantic.dev/2.10/v/model_type
4|prefect-proxy  | schedule.CronSchedule
4|prefect-proxy  |   Input should be a valid dictionary or instance of CronSchedule [type=model_type, input_value=CronSchedule(cron='0 1 * ...ezone=None, day_or=True), input_type=CronSchedule]
4|prefect-proxy  |     For further information visit https://errors.pydantic.dev/2.10/v/model_type
4|prefect-proxy  | schedule.RRuleSchedule
4|prefect-proxy  |   Input should be a valid dictionary or instance of RRuleSchedule [type=model_type, input_value=CronSchedule(cron='0 1 * ...ezone=None, day_or=True), input_type=CronSchedule]
4|prefect-proxy  |     For further information visit https://errors.pydantic.dev/2.10/v/model_type
4|prefect-proxy  | schedule.NoSchedule
4|prefect-proxy  |   Input should be a valid dictionary or instance of NoSchedule [type=model_type, input_value=CronSchedule(cron='0 1 * ...ezone=None, day_or=True), input_type=CronSchedule]
4|prefect-proxy  |     For further information visit https://errors.pydantic.dev/2.10/v/model_type
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment scheduling handling and adjusted deployment behavior for more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->