### PR TITLE
dbt cli profile block `schema` field not updating

### DIFF
--- a/proxy/service.py
+++ b/proxy/service.py
@@ -352,7 +352,7 @@ async def _create_dbt_cli_profile(
         extras["user"] = extras["username"]
         target_configs = TargetConfigs(
             type="postgres",
-            schema=payload.profile.target_configs_schema,
+            schema_=payload.profile.target_configs_schema,
             extras=extras,
             allow_field_overrides=True,
         )
@@ -361,7 +361,7 @@ async def _create_dbt_cli_profile(
         dbcredentials = GcpCredentials(service_account_info=payload.credentials)
         target_configs = BigQueryTargetConfigs(
             credentials=dbcredentials,
-            schema=payload.profile.target_configs_schema,
+            schema_=payload.profile.target_configs_schema,
             extras={
                 "location": payload.bqlocation,
             },
@@ -404,7 +404,7 @@ async def update_dbt_cli_profile(payload: DbtCliProfileBlockUpdate):
     try:
         # schema
         if payload.profile and payload.profile.target_configs_schema:
-            dbtcli_block.target_configs.schema = payload.profile.target_configs_schema
+            dbtcli_block.target_configs.schema_ = payload.profile.target_configs_schema
             dbtcli_block.target = (
                 payload.profile.target_configs_schema
             )  # by default output(s) target in profiles.yml will be target_configs_schema
@@ -546,7 +546,7 @@ async def update_postgres_credentials(dbt_blockname, new_extras):
 
     block.dbt_cli_profile.target_configs = TargetConfigs(
         type=block.dbt_cli_profile.target_configs.type,
-        schema=block.dbt_cli_profile.target_configs.model_dump()["schema"],
+        schema_=block.dbt_cli_profile.target_configs.model_dump()["schema"],
         extras=cleaned_extras,
     )
 
@@ -575,7 +575,7 @@ async def update_bigquery_credentials(dbt_blockname: str, credentials: dict):
 
     block.dbt_cli_profile.target_configs = BigQueryTargetConfigs(
         credentials=dbcredentials,
-        schema=block.dbt_cli_profile.target_configs.model_dump()["schema_"],
+        schema_=block.dbt_cli_profile.target_configs.model_dump()["schema_"],
         extras=block.dbt_cli_profile.target_configs.model_dump()["extras"],
     )
 
@@ -597,7 +597,7 @@ async def update_target_configs_schema(dbt_blockname: str, target_configs_schema
     except Exception as error:
         raise PrefectException("no dbt core op block named " + dbt_blockname) from error
 
-    block.dbt_cli_profile.target_configs.schema = target_configs_schema
+    block.dbt_cli_profile.target_configs.schema_ = target_configs_schema
     block.dbt_cli_profile.target = target_configs_schema
 
     # update the dbt command "dbt <command> --target <target>"

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -546,7 +546,7 @@ async def update_postgres_credentials(dbt_blockname, new_extras):
 
     block.dbt_cli_profile.target_configs = TargetConfigs(
         type=block.dbt_cli_profile.target_configs.type,
-        schema_=block.dbt_cli_profile.target_configs.model_dump()["schema"],
+        schema_=block.dbt_cli_profile.target_configs.model_dump()["_schema"],
         extras=cleaned_extras,
     )
 

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -546,7 +546,7 @@ async def update_postgres_credentials(dbt_blockname, new_extras):
 
     block.dbt_cli_profile.target_configs = TargetConfigs(
         type=block.dbt_cli_profile.target_configs.type,
-        schema_=block.dbt_cli_profile.target_configs.model_dump()["_schema"],
+        schema_=block.dbt_cli_profile.target_configs.model_dump()["schema_"],
         extras=cleaned_extras,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -922,7 +922,7 @@ async def test_update_postgres_credentials_success(mock_load):
                             "user": "old_user",
                             "password": "old_password",
                         },
-                        "schema": "old_schema",
+                        "schema_": "old_schema",
                     }
                 ),
                 model_dump=Mock(
@@ -933,7 +933,7 @@ async def test_update_postgres_credentials_success(mock_load):
                             "user": "old_user",
                             "password": "old_password",
                         },
-                        "schema": "old_schema",
+                        "schema_": "old_schema",
                     }
                 ),
             ),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -675,7 +675,7 @@ async def test_update_dbt_cli_profile_postgres(mock_load: AsyncMock):
         wtype="postgres",
     )
     mock_load.return_value = Mock(
-        target_configs=Mock(schema="old-schema"),
+        target_configs=Mock(schema_="old-schema"),
         save=AsyncMock(),
         dict=Mock(return_value={"_block_document_id": "_block_document_id"}),
         model_dump=Mock(return_value={"_block_document_id": "_block_document_id"}),
@@ -683,7 +683,7 @@ async def test_update_dbt_cli_profile_postgres(mock_load: AsyncMock):
     block, block_id, block_name = await update_dbt_cli_profile(payload)
     assert block_name == "block-name"
     assert block_id == "_block_document_id"
-    assert block.target_configs.schema == "new_schema"
+    assert block.target_configs.schema_ == "new_schema"
     assert block.target == "new_schema"
     assert block.name == "profile-name"
     assert block.target_configs.extras["host"] == "new_host"
@@ -1046,7 +1046,7 @@ async def test_update_target_configs_schema(mock_load):
     dbt_coreop_block.dbt_cli_profile.save.assert_called_once_with(name="block-name", overwrite=True)
     dbt_coreop_block.save.assert_called_once_with("block-name", overwrite=True)
 
-    assert dbt_coreop_block.dbt_cli_profile.target_configs.schema == "newtarget"
+    assert dbt_coreop_block.dbt_cli_profile.target_configs.schema_ == "newtarget"
     assert dbt_coreop_block.dbt_cli_profile.target == "newtarget"
     assert dbt_coreop_block.commands[0] == "dbt run --target newtarget"
 


### PR DESCRIPTION
Fix proxy #201 backend https://github.com/DalgoT4D/DDP_backend/issues/1058  Although we dont need to move to `PostgresTargetConfigs` yet. 

For users who are facing this, they should update their target schema from the transform page to reflect a correct update in cli block

It seems after pydantic v2.x the `schema()` is reserved field that pydantic models use to generate their schemas and its a method attribute. prefect-dbt exposes an alias which we should be using i,e, `schema_`

<img width="774" alt="Screenshot 2025-05-15 at 16 06 41" src="https://github.com/user-attachments/assets/474dd682-015f-4fed-82ca-dddeedfa0e34" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal attribute naming for better consistency; no impact on user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->