### PR TITLE
get scheduled flow-runs for a deployment

### DIFF
--- a/proxy/main.py
+++ b/proxy/main.py
@@ -28,6 +28,7 @@ from proxy.service import (
     get_flow_runs_by_name,
     set_deployment_schedule,
     get_deployment,
+    get_deployment_scheduled_flow_runs,
     get_flow_run,
     retry_flow_run,
     create_secret_block,
@@ -487,6 +488,19 @@ def put_dataflow_v1(deployment_id, payload: DeploymentUpdate2):
         raise HTTPException(status_code=400, detail="failed to update the deployment") from error
     logger.info("Updated the deployment: %s", deployment_id)
     return {"success": 1}
+
+
+@app.get("/proxy/v1/deployments/get_scheduled_flow_runs")
+def get_dataflow_scheduled_flow_runs(deployment_id: str):
+    """updates a deployment"""
+    try:
+        res = get_deployment_scheduled_flow_runs(deployment_id)
+    except Exception as error:
+        logger.exception(error)
+        raise HTTPException(
+            status_code=400, detail="failed to fetch scheduled flow-runs for deployment"
+        ) from error
+    return {"flow_runs": res}
 
 
 @app.post("/proxy/flow_run/")

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -492,7 +492,9 @@ def put_dataflow_v1(deployment_id, payload: DeploymentUpdate2):
 
 @app.get("/proxy/v1/deployments/get_scheduled_flow_runs")
 def get_dataflow_scheduled_flow_runs(deployment_id: str):
-    """updates a deployment"""
+    """fetch scheduled flow-runs for a deployment"""
+    if not isinstance(deployment_id, str):
+        raise TypeError("deployment_id must be a string")
     try:
         res = get_deployment_scheduled_flow_runs(deployment_id)
     except Exception as error:

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -726,7 +726,7 @@ def get_deployment(deployment_id: str) -> dict:
 
 
 def get_deployment_scheduled_flow_runs(deployment_id: str) -> dict:
-    """Fetch deployment and its details"""
+    """fetch scheduled flow-runs for a deployment"""
     if not isinstance(deployment_id, str):
         raise TypeError("deployment_id must be a string")
     res = prefect_post(

--- a/proxy/service.py
+++ b/proxy/service.py
@@ -725,6 +725,19 @@ def get_deployment(deployment_id: str) -> dict:
     return res
 
 
+def get_deployment_scheduled_flow_runs(deployment_id: str) -> dict:
+    """Fetch deployment and its details"""
+    if not isinstance(deployment_id, str):
+        raise TypeError("deployment_id must be a string")
+    res = prefect_post(
+        "deployments/get_scheduled_flow_runs",
+        {
+            "deployment_ids": [deployment_id],
+        },
+    )
+    return res
+
+
 def update_flow_run_final_state(flow_run: dict) -> dict:
     """
     fetch tasks of the flow_run & checks for the custom flow_run state

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,7 @@ from proxy.main import (
     post_run_dbtcore_flow_v1,
     post_dataflow_v1,
     put_dataflow_v1,
+    get_dataflow_scheduled_flow_runs,
     get_long_running_flows,
     patch_dbt_cloud_creds,
     get_dbt_cloud_creds,
@@ -586,6 +587,15 @@ def test_put_dataflow_v1_success():
         payload = DeploymentUpdate2(deployment_params={})
         result = put_dataflow_v1("deployment-id", payload)
         assert result == {"success": 1}
+
+
+def test_get_dataflow_scheduled_flow_runs():
+    with patch(
+        "proxy.main.get_deployment_scheduled_flow_runs"
+    ) as mock_get_deployment_scheduled_flow_runs:
+        mock_get_deployment_scheduled_flow_runs.return_value = [{"id": "flow_run_id"}]
+        result = get_dataflow_scheduled_flow_runs("deployment-id")
+        assert result == {"flow_runs": [{"id": "flow_run_id"}]}
 
 
 def test_get_flow_run_by_id_badparams():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -52,6 +52,7 @@ from proxy.service import (
     post_deployment_v1,
     put_deployment_v1,
     get_deployment,
+    get_deployment_scheduled_flow_runs,
     CronSchedule,
     post_deployment_flow_run,
     create_secret_block,
@@ -1089,6 +1090,19 @@ def test_get_deployment(mock_get: Mock):
     response = get_deployment("deployment-id")
     mock_get.assert_called_once_with(f"deployments/deployment-id")
     assert response == "retval"
+
+
+@patch("proxy.service.prefect_post")
+def test_get_deployment_scheduled_flow_runs(mock_post: Mock):
+    mock_post.return_value = [{"id": "flow_run_id"}]
+    response = get_deployment_scheduled_flow_runs("deployment-id")
+    mock_post.assert_called_once_with(
+        "deployments/get_scheduled_flow_runs",
+        {
+            "deployment_ids": ["deployment-id"],
+        },
+    )
+    assert response == [{"id": "flow_run_id"}]
 
 
 def test_get_flow_runs_by_deployment_id_type_error():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to retrieve scheduled flow runs for a specific deployment.

- **Tests**
  - Introduced tests to verify the new scheduled flow runs retrieval functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->