### PR TITLE
increase prefect retry delay and bump prefect-airbyte version

### DIFF
--- a/proxy/prefect_flows.py
+++ b/proxy/prefect_flows.py
@@ -291,7 +291,7 @@ def shellopjob(task_config: dict, task_slug: str):  # pylint: disable=unused-arg
 #         ]
 #     }
 # }
-@flow(retries=1, retry_delay_seconds=300)
+@flow(retries=1, retry_delay_seconds=600)
 def deployment_schedule_flow_v4(
     config: dict,
     dbt_blocks: list | None = None,  # pylint: disable=unused-argument

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,4 +216,4 @@ omit = [
 ]
 
 [tool.uv.sources]
-prefect-airbyte = { git = "https://github.com/Ishankoradia/prefect-airbyte.git", rev = "v0.5" }
+prefect-airbyte = { git = "https://github.com/Ishankoradia/prefect-airbyte.git", rev = "v0.7" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded an external integration dependency to v0.7 for compatibility and maintenance.
  - Adjusted task retry interval in scheduling workflows from 5 to 10 minutes to reduce retry frequency.

- Documentation
  - Updated internal notes to reflect the new retry timing and dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->